### PR TITLE
chore(version): align fastapi + version test with pyproject 0.6.1

### DIFF
--- a/interface/api/main.py
+++ b/interface/api/main.py
@@ -80,7 +80,7 @@ def create_app(container: AppContainer | None = None) -> FastAPI:
     """Build the FastAPI app. Accepts optional container for testing."""
     app = FastAPI(
         title="Morphic-Agent",
-        version="0.6.0",
+        version="0.6.1",
         lifespan=lifespan if container is None else None,
     )
 

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-EXPECTED_VERSION = "0.6.0"
+EXPECTED_VERSION = "0.6.1"
 
 
 def _read(path: str) -> str:


### PR DESCRIPTION
## Summary

- Bump `EXPECTED_VERSION` in `tests/unit/test_version_consistency.py` from `0.6.0` to `0.6.1` to match `pyproject.toml` (set in commit \`3f76672\`).
- Bump `FastAPI(version="0.6.0")` in `interface/api/main.py` to `0.6.1` so all 3 version assertions pass.
- Pre-existing CI failure on `main`; first follow-up to council pilot merge (#20).

## Test plan

- [x] `uv run --extra dev pytest tests/unit/test_version_consistency.py -v` (3/3 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- API version updated to 0.6.1
- Version consistency tests updated to reflect the new API version

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->