### PR TITLE
fix(doctor): downgrade missing optional CLI binaries from FAIL to WARN

### DIFF
--- a/interface/cli/commands/doctor.py
+++ b/interface/cli/commands/doctor.py
@@ -63,7 +63,7 @@ def _check_cli_binary(name: str, binary: str) -> _Check:
     path = shutil.which(binary)
     if path:
         return _Check(name, "OK", f"Found at {path}")
-    return _Check(name, "FAIL", f"'{binary}' not found in PATH")
+    return _Check(name, "WARN", f"'{binary}' not found in PATH (optional)")
 
 
 def _check_api_keys(container) -> list[_Check]:  # type: ignore[type-arg]

--- a/tests/unit/interface/test_doctor_cli.py
+++ b/tests/unit/interface/test_doctor_cli.py
@@ -124,6 +124,16 @@ class TestDoctorCheck:
         result = runner.invoke(app, ["doctor", "check"])
         assert "OpenHands" in result.output
 
+    def test_missing_optional_clis_do_not_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CI envs without claude/gemini/codex binaries should still exit 0."""
+        from interface.cli.commands import doctor as doctor_mod
+
+        monkeypatch.setattr(doctor_mod.shutil, "which", lambda _b: None)
+        result = runner.invoke(app, ["doctor", "check"])
+        assert result.exit_code == 0
+        assert "WARN" in result.output
+        assert "optional" in result.output
+
 
 # ── Docker check unit tests ──
 


### PR DESCRIPTION
## Summary
`morphic doctor check` was exiting 1 in CI because the runner doesn't have `claude`/`gemini`/`codex` CLIs installed, and \`_check_cli_binary\` treated their absence as **FAIL** instead of **WARN**.

## Root cause
\`\`\`python
def _check_cli_binary(name: str, binary: str) -> _Check:
    path = shutil.which(binary)
    if path:
        return _Check(name, "OK", f"Found at {path}")
    return _Check(name, "FAIL", f"'{binary}' not found in PATH")  # <-- wrong severity
\`\`\`
Any FAIL triggers \`raise typer.Exit(code=1)\`. But these CLIs are *optional engines* in our Ollama-first design — every other optional check (Docker, OpenHands, engine availability, API keys) uses WARN.

## Fix
- Downgrade \`_check_cli_binary\` missing-binary case to WARN, with message suffix \`(optional)\`
- Add regression test \`test_missing_optional_clis_do_not_fail\` that simulates a CI env via \`shutil.which\` monkeypatch

## Test plan
- [x] All 19 \`test_doctor_cli.py\` tests pass locally
- [x] \`ruff check\` clean
- [ ] CI \`unit-tests\` job turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The health check command now displays warnings for missing optional CLI binaries instead of failing, allowing the check to complete successfully when these components are unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->