### PR TITLE
refactor(council): relocate DebateEvent vocabulary to value_objects

### DIFF
--- a/application/use_cases/run_council_debate.py
+++ b/application/use_cases/run_council_debate.py
@@ -14,16 +14,16 @@ import logging
 import uuid
 
 from domain.entities.cognitive import Decision
-from domain.entities.council import (
+from domain.entities.council import SubtaskBrief
+from domain.ports.council_debate import CouncilDebatePort
+from domain.ports.event_bus import EventBusPort
+from domain.value_objects.agent_engine import AgentEngineType
+from domain.value_objects.council_events import (
     ArgumentSubmitted,
     DebateAbandoned,
     DebateStarted,
     DecisionResolved,
-    SubtaskBrief,
 )
-from domain.ports.council_debate import CouncilDebatePort
-from domain.ports.event_bus import EventBusPort
-from domain.value_objects.agent_engine import AgentEngineType
 
 logger = logging.getLogger(__name__)
 

--- a/domain/entities/council.py
+++ b/domain/entities/council.py
@@ -1,22 +1,17 @@
-"""Council entities — debate primitives + publish-only event vocabulary.
+"""Council entities — debate primitives.
+
+`Argument` and `SubtaskBrief` are the domain inputs/outputs of a council
+debate. The event vocabulary (`DebateEvent` discriminated union) lives in
+`domain/value_objects/council_events.py` since events are immutable
+value objects with no identity beyond their data.
 
 Spec: `specs/council-pilot/spec.md` (FR-3, FR-4).
-Plan: `specs/council-pilot/plan.md` §Data Model.
-
-The `DebateEvent` discriminated union is the contract that the next sprint's
-SSE/WebSocket renderer subscribes to. The `Decision` entity is reused
-unchanged from `domain/entities/cognitive.py` (FR-4).
 """
 
 from __future__ import annotations
 
-import uuid
-from datetime import datetime
-from typing import Annotated, Literal
+from pydantic import BaseModel, Field
 
-from pydantic import BaseModel, Field, TypeAdapter
-
-from domain.entities.cognitive import Decision
 from domain.value_objects.agent_engine import AgentEngineType
 from domain.value_objects.model_tier import TaskType
 
@@ -37,41 +32,3 @@ class SubtaskBrief(BaseModel):
     id: str = Field(min_length=1)
     description: str = Field(min_length=1)
     task_type: TaskType
-
-
-class _BaseEvent(BaseModel):
-    debate_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-
-
-class DebateStarted(_BaseEvent):
-    kind: Literal["debate_started"] = "debate_started"
-    subtask: SubtaskBrief
-    candidates: list[AgentEngineType]
-    started_at: datetime = Field(default_factory=datetime.now)
-
-
-class ArgumentSubmitted(_BaseEvent):
-    kind: Literal["argument_submitted"] = "argument_submitted"
-    argument: Argument
-    submitted_at: datetime = Field(default_factory=datetime.now)
-
-
-class DecisionResolved(_BaseEvent):
-    kind: Literal["decision_resolved"] = "decision_resolved"
-    decision: Decision
-    arguments: list[Argument]
-    resolved_at: datetime = Field(default_factory=datetime.now)
-
-
-class DebateAbandoned(_BaseEvent):
-    kind: Literal["debate_abandoned"] = "debate_abandoned"
-    reason: str = Field(min_length=1)
-    abandoned_at: datetime = Field(default_factory=datetime.now)
-
-
-DebateEvent = Annotated[
-    DebateStarted | ArgumentSubmitted | DecisionResolved | DebateAbandoned,
-    Field(discriminator="kind"),
-]
-
-DebateEventAdapter: TypeAdapter[DebateEvent] = TypeAdapter(DebateEvent)

--- a/domain/ports/event_bus.py
+++ b/domain/ports/event_bus.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from domain.entities.council import DebateEvent
+from domain.value_objects.council_events import DebateEvent
 
 
 class EventBusPort(ABC):

--- a/domain/value_objects/council_events.py
+++ b/domain/value_objects/council_events.py
@@ -1,0 +1,60 @@
+"""Council debate events — immutable, publish-only event vocabulary.
+
+These events are value objects (no identity beyond their data) emitted by the
+council debate use case and consumed by `EventBusPort` implementations. The
+`DebateEvent` discriminated union is the contract that the next sprint's
+SSE/WebSocket renderer subscribes to.
+
+Spec: `specs/council-pilot/spec.md` (FR-3, FR-4).
+Plan: `specs/council-pilot/plan.md` §Data Model.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, TypeAdapter
+
+from domain.entities.cognitive import Decision
+from domain.entities.council import Argument, SubtaskBrief
+from domain.value_objects.agent_engine import AgentEngineType
+
+
+class _BaseEvent(BaseModel):
+    debate_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+
+
+class DebateStarted(_BaseEvent):
+    kind: Literal["debate_started"] = "debate_started"
+    subtask: SubtaskBrief
+    candidates: list[AgentEngineType]
+    started_at: datetime = Field(default_factory=datetime.now)
+
+
+class ArgumentSubmitted(_BaseEvent):
+    kind: Literal["argument_submitted"] = "argument_submitted"
+    argument: Argument
+    submitted_at: datetime = Field(default_factory=datetime.now)
+
+
+class DecisionResolved(_BaseEvent):
+    kind: Literal["decision_resolved"] = "decision_resolved"
+    decision: Decision
+    arguments: list[Argument]
+    resolved_at: datetime = Field(default_factory=datetime.now)
+
+
+class DebateAbandoned(_BaseEvent):
+    kind: Literal["debate_abandoned"] = "debate_abandoned"
+    reason: str = Field(min_length=1)
+    abandoned_at: datetime = Field(default_factory=datetime.now)
+
+
+DebateEvent = Annotated[
+    DebateStarted | ArgumentSubmitted | DecisionResolved | DebateAbandoned,
+    Field(discriminator="kind"),
+]
+
+DebateEventAdapter: TypeAdapter[DebateEvent] = TypeAdapter(DebateEvent)

--- a/infrastructure/events/in_memory_event_bus.py
+++ b/infrastructure/events/in_memory_event_bus.py
@@ -6,8 +6,8 @@ Plan: `specs/council-pilot/plan.md` §Infrastructure impls.
 
 from __future__ import annotations
 
-from domain.entities.council import DebateEvent
 from domain.ports.event_bus import EventBusPort
+from domain.value_objects.council_events import DebateEvent
 
 
 class InMemoryEventBus(EventBusPort):

--- a/tests/integration/test_council_pilot_live.py
+++ b/tests/integration/test_council_pilot_live.py
@@ -22,12 +22,9 @@ import time
 import pytest
 
 from application.use_cases.run_council_debate import RunCouncilDebateUseCase  # noqa: E402
-from domain.entities.council import (
-    DebateStarted,
-    DecisionResolved,
-    SubtaskBrief,
-)
+from domain.entities.council import SubtaskBrief
 from domain.value_objects.agent_engine import AgentEngineType
+from domain.value_objects.council_events import DebateStarted, DecisionResolved
 from domain.value_objects.model_tier import TaskType
 from infrastructure.council.two_engine_debate import TwoEngineDebate
 from infrastructure.events.in_memory_event_bus import InMemoryEventBus

--- a/tests/unit/application/_fakes/in_memory_event_bus.py
+++ b/tests/unit/application/_fakes/in_memory_event_bus.py
@@ -8,8 +8,8 @@ grow features the unit tests do not care about).
 
 from __future__ import annotations
 
-from domain.entities.council import DebateEvent
 from domain.ports.event_bus import EventBusPort
+from domain.value_objects.council_events import DebateEvent
 
 
 class FakeEventBus(EventBusPort):

--- a/tests/unit/application/test_run_council_debate.py
+++ b/tests/unit/application/test_run_council_debate.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 import pytest
 
 from domain.entities.cognitive import Decision
-from domain.entities.council import (
-    Argument,
+from domain.entities.council import Argument, SubtaskBrief
+from domain.value_objects.agent_engine import AgentEngineType
+from domain.value_objects.council_events import (
     ArgumentSubmitted,
     DebateAbandoned,
     DebateStarted,
     DecisionResolved,
-    SubtaskBrief,
 )
-from domain.value_objects.agent_engine import AgentEngineType
 from domain.value_objects.model_tier import TaskType
 from tests.unit.application._fakes.fake_council_debate import FakeCouncilDebate
 from tests.unit.application._fakes.in_memory_event_bus import FakeEventBus

--- a/tests/unit/domain/test_council_entities.py
+++ b/tests/unit/domain/test_council_entities.py
@@ -9,13 +9,9 @@ import pytest
 from pydantic import ValidationError
 
 from domain.entities.cognitive import Decision
-from domain.entities.council import (
-    Argument,
-    DebateStarted,
-    DecisionResolved,
-    SubtaskBrief,
-)
+from domain.entities.council import Argument, SubtaskBrief
 from domain.value_objects.agent_engine import AgentEngineType
+from domain.value_objects.council_events import DebateStarted, DecisionResolved
 from domain.value_objects.model_tier import TaskType
 
 
@@ -50,7 +46,7 @@ def test_debate_event_discriminator() -> None:
     resolved = DecisionResolved(decision=decision, arguments=arguments)
     payload = resolved.model_dump_json()
 
-    from domain.entities.council import DebateEventAdapter
+    from domain.value_objects.council_events import DebateEventAdapter
 
     parsed = DebateEventAdapter.validate_json(payload)
     assert isinstance(parsed, DecisionResolved)


### PR DESCRIPTION
## Summary
Council pilot reviewer nit: debate events are immutable records with no identity beyond their data — that is the value-object definition, so they belong under \`domain/value_objects/\`. \`Argument\` and \`SubtaskBrief\` stay in \`domain/entities/council\` (they are the debate inputs/outputs; \`SubtaskBrief\` carries an \`id\`).

## Changes
- **NEW** \`domain/value_objects/council_events.py\` — \`DebateStarted\` / \`ArgumentSubmitted\` / \`DecisionResolved\` / \`DebateAbandoned\` / \`DebateEvent\` / \`DebateEventAdapter\`
- **SLIM** \`domain/entities/council.py\` — now only \`Argument\` + \`SubtaskBrief\`
- Update imports in:
  - \`application/use_cases/run_council_debate.py\`
  - \`domain/ports/event_bus.py\`
  - \`infrastructure/events/in_memory_event_bus.py\`
  - \`tests/unit/application/_fakes/in_memory_event_bus.py\`
  - \`tests/unit/domain/test_council_entities.py\`
  - \`tests/unit/application/test_run_council_debate.py\`
  - \`tests/integration/test_council_pilot_live.py\`

No behavior change.

## Test plan
- [x] 11 council unit tests pass locally
- [x] Full unit suite: 3,177 pass / 1 fail (pre-existing version-consistency mismatch tracked in PR #21)
- [x] \`ruff check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure for improved maintainability and clarity. Event handling logic has been consolidated and streamlined without impacting existing functionality or user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->