### PR TITLE
fix(council): type task_state_repo as port + fix FR-10 add_decision bug

### DIFF
--- a/application/use_cases/route_to_engine.py
+++ b/application/use_cases/route_to_engine.py
@@ -17,9 +17,11 @@ from dataclasses import dataclass
 from application.use_cases.run_council_debate import RunCouncilDebateUseCase
 from domain.entities.cognitive import AgentAction, Decision
 from domain.entities.council import SubtaskBrief
+from domain.ports.agent_affinity_repository import AgentAffinityRepository
 from domain.ports.agent_engine import AgentEngineCapabilities, AgentEnginePort, AgentEngineResult
 from domain.ports.context_adapter import ContextAdapterPort
 from domain.ports.engine_cost_recorder import EngineCostRecorderPort
+from domain.ports.shared_task_state_repository import SharedTaskStateRepository
 from domain.services.agent_engine_router import AgentEngineRouter
 from domain.services.topic_extractor import TopicExtractor
 from domain.value_objects.agent_engine import AgentEngineType
@@ -27,10 +29,6 @@ from domain.value_objects.fallback_attempt import FallbackAttempt
 from domain.value_objects.model_tier import TaskType
 
 logger = logging.getLogger(__name__)
-
-# Lazy imports to avoid circular — these are optional deps
-_AgentAffinityRepository = None
-_SharedTaskStateRepository = None
 
 
 @dataclass
@@ -52,8 +50,8 @@ class RouteToEngineUseCase:
         self,
         drivers: dict[AgentEngineType, AgentEnginePort],
         context_adapters: dict[AgentEngineType, ContextAdapterPort] | None = None,
-        affinity_repo: object | None = None,  # AgentAffinityRepository
-        task_state_repo: object | None = None,  # SharedTaskStateRepository
+        affinity_repo: AgentAffinityRepository | None = None,
+        task_state_repo: SharedTaskStateRepository | None = None,
         affinity_min_samples: int = 3,
         affinity_boost_threshold: float = 0.6,
         cost_tracker: EngineCostRecorderPort | None = None,
@@ -373,11 +371,21 @@ class RouteToEngineUseCase:
         task_id: str | None,
         decision: Decision,
     ) -> None:
-        """Record council Decision to SharedTaskState (FR-10, fire-and-forget)."""
+        """Record council Decision to SharedTaskState (FR-10, fire-and-forget).
+
+        Uses the existing SharedTaskStateRepository port: fetch state,
+        append the decision via the entity method, then persist with
+        update_decisions. The port has no add_decision(task_id, decision)
+        method — the entity owns that mutation.
+        """
         if task_id is None or self._task_state_repo is None:
             return
         try:
-            await self._task_state_repo.add_decision(task_id, decision)  # type: ignore[union-attr]
+            state = await self._task_state_repo.get(task_id)
+            if state is None:
+                return
+            state.add_decision(decision)
+            await self._task_state_repo.update_decisions(state)
         except Exception:
             logger.debug("Failed to record council decision for task=%s", task_id)
 
@@ -397,7 +405,7 @@ class RouteToEngineUseCase:
         if task_id and self._context_adapters and self._task_state_repo:
             adapter = self._context_adapters.get(engine_type)
             if adapter:
-                state = await self._task_state_repo.get(task_id)  # type: ignore[union-attr]
+                state = await self._task_state_repo.get(task_id)
                 if state is not None:
                     memory_ctx = context or ""
                     injected = adapter.inject_context(
@@ -416,7 +424,7 @@ class RouteToEngineUseCase:
         if self._affinity_repo is None:
             return []
         try:
-            return await self._affinity_repo.get_by_topic(topic)  # type: ignore[union-attr]
+            return await self._affinity_repo.get_by_topic(topic)
         except Exception:
             logger.debug("Failed to fetch affinities for topic=%s", topic)
             return []
@@ -458,7 +466,7 @@ class RouteToEngineUseCase:
         try:
             from domain.entities.cognitive import AgentAffinityScore
 
-            existing = await self._affinity_repo.get(engine_type, topic)  # type: ignore[union-attr]
+            existing = await self._affinity_repo.get(engine_type, topic)
             if existing is not None:
                 # Incremental update
                 new_count = existing.sample_count + 1
@@ -485,7 +493,7 @@ class RouteToEngineUseCase:
                     cost_efficiency=0.5,
                     sample_count=1,
                 )
-            await self._affinity_repo.upsert(updated)  # type: ignore[union-attr]
+            await self._affinity_repo.upsert(updated)
         except Exception:
             logger.debug("Failed to update affinity for %s/%s", engine_type.value, topic)
 
@@ -507,7 +515,7 @@ class RouteToEngineUseCase:
                 cost_usd=result.cost_usd,
                 duration_seconds=duration,
             )
-            await self._task_state_repo.append_action(task_id, action)  # type: ignore[union-attr]
+            await self._task_state_repo.append_action(task_id, action)
         except Exception:
             logger.debug("Failed to record action for task=%s", task_id)
 

--- a/tests/unit/application/test_route_to_engine_council.py
+++ b/tests/unit/application/test_route_to_engine_council.py
@@ -6,7 +6,7 @@ import pytest
 
 from application.use_cases.route_to_engine import RouteToEngineUseCase
 from application.use_cases.run_council_debate import RunCouncilDebateUseCase
-from domain.entities.cognitive import Decision
+from domain.entities.cognitive import Decision, SharedTaskState
 from domain.entities.council import Argument
 from domain.services.agent_engine_router import AgentEngineRouter
 from domain.value_objects.agent_engine import AgentEngineType
@@ -122,3 +122,65 @@ async def test_council_enabled_abandoned_chain_unchanged() -> None:
         task_id=None,
     )
     assert chain == _baseline_chain()
+
+
+class _StubTaskStateRepo:
+    """Minimal in-memory SharedTaskStateRepository for FR-10 verification."""
+
+    def __init__(self, initial: SharedTaskState | None = None) -> None:
+        self._state = initial
+        self.updated_decisions: list[Decision] = []
+
+    async def get(self, task_id: str) -> SharedTaskState | None:
+        return self._state
+
+    async def update_decisions(self, state: SharedTaskState) -> None:
+        self.updated_decisions = list(state.decisions)
+
+    async def save(self, state: SharedTaskState) -> None: ...
+    async def list_active(self) -> list[SharedTaskState]:
+        return []
+    async def update_artifacts(self, state: SharedTaskState) -> None: ...
+    async def append_action(self, task_id, action) -> None: ...  # type: ignore[no-untyped-def]
+    async def delete(self, task_id: str) -> None: ...
+
+
+@pytest.mark.asyncio
+async def test_record_council_decision_persists_via_port_methods() -> None:
+    """FR-10: council Decision is appended to SharedTaskState via get + update_decisions.
+
+    Regression for T-41: previously called a non-existent
+    ``add_decision(task_id, decision)`` on the port — the call always
+    raised AttributeError, was swallowed, and the decision was never
+    persisted. Type-ignore was masking the bug.
+    """
+    state = SharedTaskState(task_id="t1")
+    repo = _StubTaskStateRepo(initial=state)
+    uc = RouteToEngineUseCase(drivers={}, task_state_repo=repo)
+
+    decision = Decision(
+        description="picked engine",
+        agent_engine=AgentEngineType.GEMINI_CLI,
+        rationale="cheapest",
+    )
+    await uc._record_council_decision(task_id="t1", decision=decision)
+
+    assert len(repo.updated_decisions) == 1
+    assert repo.updated_decisions[0].agent_engine is AgentEngineType.GEMINI_CLI
+
+
+@pytest.mark.asyncio
+async def test_record_council_decision_skips_when_state_missing() -> None:
+    """When the SharedTaskState lookup returns None, no update is attempted."""
+    repo = _StubTaskStateRepo(initial=None)
+    uc = RouteToEngineUseCase(drivers={}, task_state_repo=repo)
+
+    await uc._record_council_decision(
+        task_id="missing",
+        decision=Decision(
+            description="x",
+            agent_engine=AgentEngineType.OLLAMA,
+            rationale="y",
+        ),
+    )
+    assert repo.updated_decisions == []


### PR DESCRIPTION
## Summary
- Type `affinity_repo` and `task_state_repo` constructor params as their domain ports (`AgentAffinityRepository`, `SharedTaskStateRepository`) instead of `object` — removes all 4 `# type: ignore[union-attr]` instances in `RouteToEngineUseCase` (reviewer nit T-41).
- Fix a latent FR-10 bug masked by the ignore: `_record_council_decision` was calling `self._task_state_repo.add_decision(task_id, decision)`, which the port doesn't expose. The call always raised `AttributeError`, the broad `except` swallowed it, and the council `Decision` was never persisted. Now uses the entity-owned mutation: `get` → `state.add_decision(decision)` → `update_decisions(state)`.
- Adds 2 regression tests covering the persist path and the missing-state branch.

## Test plan
- [x] `pytest tests/unit/application/test_route_to_engine{,_council}.py tests/unit/application/test_run_council_debate.py` — 65 passed
- [x] Full unit suite: 3,181 passed (1 pre-existing version mismatch tracked in PR #21)
- [x] `ruff check` clean on edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced type safety for repository dependencies by replacing generic placeholders with concrete types
  * Corrected council decision recording to properly retrieve shared state, apply decisions, and persist updates via repository methods

* **Tests**
  * Added test coverage for decision persistence flow when state is present
  * Added test coverage for decision handling when state is unavailable

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->