### PR TITLE
feat(cost): TD-189 step 1 — add CostRecord.task_id

### DIFF
--- a/domain/entities/cost.py
+++ b/domain/entities/cost.py
@@ -23,6 +23,7 @@ class CostRecord(BaseModel):
     cached_tokens: int = Field(default=0, ge=0)
     is_local: bool = False
     engine_type: str | None = None
+    task_id: str | None = None
     timestamp: datetime = Field(default_factory=datetime.now)
 
     @classmethod

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -163,6 +163,15 @@ class TestCostRecord:
         assert record.cost_usd == 0.0045
         assert record.is_local is False
 
+    def test_task_id_optional_default_none(self):
+        record = CostRecord(model="claude-sonnet-4-6")
+        assert record.task_id is None
+
+    def test_task_id_round_trip(self):
+        record = CostRecord(model="claude-sonnet-4-6", task_id="task-abc")
+        rebuilt = CostRecord.model_validate_json(record.model_dump_json())
+        assert rebuilt.task_id == "task-abc"
+
 
 # ══════════════════════════════════════════════════════════════════
 #  Strict Validation Tests — ConfigDict(strict=True) enforcement


### PR DESCRIPTION
## Summary
- Add optional `task_id: str | None = None` to `CostRecord` domain entity
- 2 RED→GREEN tests in `test_entities.py` (default None + JSON round-trip)
- First of 4 atomic commits for TD-189 (per-task cache_hit_rate aggregation)

## Why
TD-188 deferred per-task `cache_hit_rate` aggregation pending CostRecord ↔ task_id linkage. This is the smallest viable starting point — domain entity gains the optional column, downstream wiring follows.

## Test plan
- [x] `pytest tests/unit/domain/test_entities.py` — 53 pass
- [x] Full unit suite — 3182 pass, 0 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost records can now be optionally linked to specific tasks, enabling improved cost tracking at the task level and better expense attribution. This enhancement allows users to associate costs with individual tasks for enhanced financial visibility and more detailed reporting capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/27)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->