### PR TITLE
feat(cost): TD-189 step 2 — per-task cache_hit_rate aggregation port

### DIFF
--- a/domain/ports/cost_repository.py
+++ b/domain/ports/cost_repository.py
@@ -22,3 +22,13 @@ class CostRepository(ABC):
 
     @abstractmethod
     async def list_recent(self, limit: int = 50) -> list[CostRecord]: ...
+
+    @abstractmethod
+    async def get_cache_hit_rate_for_task(self, task_id: str) -> float:
+        """Cache-hit ratio for a single task across all of its CostRecords.
+
+        Returns ratio in [0.0, 1.0] computed as
+        ``sum(cached_tokens) / sum(prompt_tokens + cached_tokens)`` over all
+        records whose ``task_id`` matches. Returns 0.0 when no records exist
+        or when the denominator is zero (e.g. only engine costs were tracked).
+        """

--- a/infrastructure/persistence/in_memory.py
+++ b/infrastructure/persistence/in_memory.py
@@ -74,6 +74,19 @@ class InMemoryCostRepository(CostRepository):
     async def list_recent(self, limit: int = 50) -> list[CostRecord]:
         return sorted(self._records, key=lambda r: r.timestamp, reverse=True)[:limit]
 
+    async def get_cache_hit_rate_for_task(self, task_id: str) -> float:
+        cached = 0
+        prompt = 0
+        for r in self._records:
+            if r.task_id != task_id:
+                continue
+            cached += r.cached_tokens
+            prompt += r.prompt_tokens
+        denom = cached + prompt
+        if denom == 0:
+            return 0.0
+        return cached / denom
+
 
 class InMemoryMemoryRepository(MemoryRepository):
     """Dict-backed MemoryRepository with optional embedding-based vector search.

--- a/infrastructure/persistence/pg_cost_repository.py
+++ b/infrastructure/persistence/pg_cost_repository.py
@@ -85,3 +85,9 @@ class PgCostRepository(CostRepository):
             stmt = select(CostLogModel).order_by(CostLogModel.created_at.desc()).limit(limit)
             result = await session.execute(stmt)
             return [self._to_entity(row) for row in result.scalars().all()]
+
+    async def get_cache_hit_rate_for_task(self, task_id: str) -> float:
+        # TD-189 step 3 wires the actual SQL once the cost_logs.task_id
+        # column + Alembic migration land. Until then this stays a no-op
+        # so production code paths fall back to the existing 0.0 default.
+        return 0.0

--- a/tests/unit/infrastructure/test_in_memory_cost_repo_per_task.py
+++ b/tests/unit/infrastructure/test_in_memory_cost_repo_per_task.py
@@ -1,0 +1,124 @@
+"""TD-189 step 2: InMemoryCostRepository.get_cache_hit_rate_for_task.
+
+RED → GREEN coverage for the per-task cache_hit_rate aggregation that
+ExecuteTaskUseCase will use to populate ExecutionRecord.cache_hit_rate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.entities.cost import CostRecord
+from infrastructure.persistence.in_memory import InMemoryCostRepository
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_no_records() -> None:
+    repo = InMemoryCostRepository()
+    assert await repo.get_cache_hit_rate_for_task("missing") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_only_other_tasks() -> None:
+    repo = InMemoryCostRepository()
+    await repo.save(
+        CostRecord(
+            model="claude-sonnet-4-6",
+            prompt_tokens=100,
+            cached_tokens=80,
+            task_id="other",
+        )
+    )
+    assert await repo.get_cache_hit_rate_for_task("target") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_single_record_ratio() -> None:
+    repo = InMemoryCostRepository()
+    await repo.save(
+        CostRecord(
+            model="claude-sonnet-4-6",
+            prompt_tokens=200,
+            cached_tokens=800,
+            task_id="t1",
+        )
+    )
+    rate = await repo.get_cache_hit_rate_for_task("t1")
+    assert rate == pytest.approx(0.8)
+
+
+@pytest.mark.asyncio
+async def test_aggregates_multiple_records_for_same_task() -> None:
+    repo = InMemoryCostRepository()
+    await repo.save(
+        CostRecord(
+            model="claude-sonnet-4-6",
+            prompt_tokens=100,
+            cached_tokens=0,
+            task_id="t1",
+        )
+    )
+    await repo.save(
+        CostRecord(
+            model="claude-sonnet-4-6",
+            prompt_tokens=300,
+            cached_tokens=600,
+            task_id="t1",
+        )
+    )
+    rate = await repo.get_cache_hit_rate_for_task("t1")
+    # cached=600, prompt=400, denom=1000 → 0.6
+    assert rate == pytest.approx(0.6)
+
+
+@pytest.mark.asyncio
+async def test_excludes_other_task_records() -> None:
+    repo = InMemoryCostRepository()
+    await repo.save(
+        CostRecord(
+            model="claude-sonnet-4-6",
+            prompt_tokens=10,
+            cached_tokens=90,
+            task_id="t1",
+        )
+    )
+    await repo.save(
+        CostRecord(
+            model="claude-sonnet-4-6",
+            prompt_tokens=999,
+            cached_tokens=0,
+            task_id="t2",
+        )
+    )
+    assert await repo.get_cache_hit_rate_for_task("t1") == pytest.approx(0.9)
+    assert await repo.get_cache_hit_rate_for_task("t2") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_zero_denominator_returns_zero() -> None:
+    """Engine-only cost records (no token counts) must not divide by zero."""
+    repo = InMemoryCostRepository()
+    await repo.save(
+        CostRecord(
+            model="engine/codex_cli",
+            prompt_tokens=0,
+            cached_tokens=0,
+            cost_usd=0.04,
+            engine_type="codex_cli",
+            task_id="t1",
+        )
+    )
+    assert await repo.get_cache_hit_rate_for_task("t1") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_records_without_task_id_are_ignored() -> None:
+    repo = InMemoryCostRepository()
+    await repo.save(
+        CostRecord(
+            model="claude-sonnet-4-6",
+            prompt_tokens=100,
+            cached_tokens=900,
+        )  # task_id=None
+    )
+    assert await repo.get_cache_hit_rate_for_task("t1") == 0.0


### PR DESCRIPTION
## Summary
- Adds `CostRepository.get_cache_hit_rate_for_task(task_id)` to the port (`domain/ports/cost_repository.py`)
- Implements real aggregation in `InMemoryCostRepository` — `sum(cached) / sum(prompt + cached)` over matching records, 0.0 when no records or zero denominator
- Stubs `PgCostRepository` to return 0.0 with a TODO pointing to step 3 (the SQL needs the `cost_logs.task_id` column + Alembic migration)

This is step 2 of 4 in the TD-189 series (per-task `cache_hit_rate` for `ExecutionRecord`). Step 1 (`CostRecord.task_id` field) merged in #27.

## Test plan
- [x] 7 new RED→GREEN cases in `tests/unit/infrastructure/test_in_memory_cost_repo_per_task.py`
- [x] Full unit suite: 3,211 passed, 0 regressions
- [x] `ruff check` clean
- [ ] Step 3 will replace the PG stub once the column lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-task cache hit rate calculation capability, enabling measurement of caching effectiveness at the individual task level.

* **Tests**
  * New test suite ensures robust cache hit rate computation across various conditions including empty records, multiple tasks, and boundary cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->