### PR TITLE
feat(cost): TD-189 step 3 — cost_logs.task_id migration + PG SQL

### DIFF
--- a/infrastructure/persistence/models.py
+++ b/infrastructure/persistence/models.py
@@ -122,6 +122,7 @@ class CostLogModel(Base):
     cost_usd: Mapped[Decimal] = mapped_column(Numeric(10, 6), default=Decimal("0"))
     cached_tokens: Mapped[int] = mapped_column(Integer, default=0)
     is_local: Mapped[bool] = mapped_column(Boolean, default=False)
+    task_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 

--- a/infrastructure/persistence/pg_cost_repository.py
+++ b/infrastructure/persistence/pg_cost_repository.py
@@ -28,6 +28,7 @@ class PgCostRepository(CostRepository):
             cost_usd=Decimal(str(record.cost_usd)),
             cached_tokens=record.cached_tokens,
             is_local=record.is_local,
+            task_id=record.task_id,
             created_at=record.timestamp,
         )
 
@@ -40,6 +41,7 @@ class PgCostRepository(CostRepository):
             cost_usd=float(model.cost_usd),
             cached_tokens=model.cached_tokens,
             is_local=model.is_local,
+            task_id=model.task_id,
             timestamp=model.created_at,
         )
 
@@ -87,7 +89,14 @@ class PgCostRepository(CostRepository):
             return [self._to_entity(row) for row in result.scalars().all()]
 
     async def get_cache_hit_rate_for_task(self, task_id: str) -> float:
-        # TD-189 step 3 wires the actual SQL once the cost_logs.task_id
-        # column + Alembic migration land. Until then this stays a no-op
-        # so production code paths fall back to the existing 0.0 default.
-        return 0.0
+        async with self._session_factory() as session:
+            stmt = select(
+                func.coalesce(func.sum(CostLogModel.cached_tokens), 0),
+                func.coalesce(func.sum(CostLogModel.prompt_tokens), 0),
+            ).where(CostLogModel.task_id == task_id)
+            row = (await session.execute(stmt)).one()
+            cached, prompt = int(row[0]), int(row[1])
+            denom = cached + prompt
+            if denom == 0:
+                return 0.0
+            return cached / denom

--- a/migrations/versions/005_add_cost_logs_task_id.py
+++ b/migrations/versions/005_add_cost_logs_task_id.py
@@ -1,0 +1,37 @@
+"""005 add task_id column to cost_logs
+
+Revision ID: 005_cost_logs_task_id
+Revises: 004_exec_affinity_state
+Create Date: 2026-05-14
+
+TD-189 step 3: per-task cache_hit_rate aggregation needs cost_logs.task_id
+so PgCostRepository.get_cache_hit_rate_for_task can group records by task.
+Nullable so existing rows remain valid.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "005_cost_logs_task_id"
+down_revision = "004_exec_affinity_state"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cost_logs",
+        sa.Column("task_id", sa.String(255), nullable=True),
+    )
+    op.create_index(
+        "ix_cost_logs_task_id",
+        "cost_logs",
+        ["task_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_cost_logs_task_id", table_name="cost_logs")
+    op.drop_column("cost_logs", "task_id")

--- a/tests/unit/infrastructure/test_pg_repositories.py
+++ b/tests/unit/infrastructure/test_pg_repositories.py
@@ -107,6 +107,18 @@ class TestPgCostRepositoryMapping:
         assert model.is_local is True
         assert model.cost_usd == Decimal("0")
 
+    def test_task_id_round_trip(self) -> None:
+        record = CostRecord(model="claude-sonnet-4-6", task_id="task-xyz")
+        model = PgCostRepository._to_model(record)
+        assert model.task_id == "task-xyz"
+        roundtrip = PgCostRepository._to_entity(model)
+        assert roundtrip.task_id == "task-xyz"
+
+    def test_task_id_defaults_to_none(self) -> None:
+        record = CostRecord(model="claude-sonnet-4-6")
+        model = PgCostRepository._to_model(record)
+        assert model.task_id is None
+
 
 class TestPgMemoryRepositoryMapping:
     def test_to_model_and_back(self) -> None:
@@ -264,6 +276,55 @@ class TestPgCostRepositorySave:
         await repo.save(record)
         session.add.assert_called_once()
         session.commit.assert_awaited_once()
+
+
+class TestPgCostRepositoryCacheHitRate:
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_records(self) -> None:
+        factory, session = _mock_session_factory()
+        mock_result = MagicMock()
+        mock_result.one.return_value = (0, 0)
+        session.execute = AsyncMock(return_value=mock_result)
+        repo = PgCostRepository(factory)
+        rate = await repo.get_cache_hit_rate_for_task("missing")
+        assert rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_computes_ratio_from_sums(self) -> None:
+        factory, session = _mock_session_factory()
+        mock_result = MagicMock()
+        mock_result.one.return_value = (600, 400)  # cached, prompt
+        session.execute = AsyncMock(return_value=mock_result)
+        repo = PgCostRepository(factory)
+        rate = await repo.get_cache_hit_rate_for_task("t1")
+        # 600 / (600 + 400) = 0.6
+        assert rate == pytest.approx(0.6)
+
+    @pytest.mark.asyncio
+    async def test_zero_denominator_returns_zero(self) -> None:
+        """Engine-only records (no tokens) must not divide by zero."""
+        factory, session = _mock_session_factory()
+        mock_result = MagicMock()
+        mock_result.one.return_value = (0, 0)
+        session.execute = AsyncMock(return_value=mock_result)
+        repo = PgCostRepository(factory)
+        rate = await repo.get_cache_hit_rate_for_task("engine-only")
+        assert rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_query_filters_by_task_id(self) -> None:
+        """SQL WHERE clause must reference the task_id parameter."""
+        factory, session = _mock_session_factory()
+        mock_result = MagicMock()
+        mock_result.one.return_value = (10, 90)
+        session.execute = AsyncMock(return_value=mock_result)
+        repo = PgCostRepository(factory)
+        await repo.get_cache_hit_rate_for_task("specific-task")
+        session.execute.assert_awaited_once()
+        executed_stmt = session.execute.await_args.args[0]
+        compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "cost_logs.task_id" in compiled
+        assert "specific-task" in compiled
 
 
 class TestPgMemoryRepositoryAdd:


### PR DESCRIPTION
## Summary
- Adds nullable `task_id VARCHAR(255)` column + index to `cost_logs` via Alembic migration `005_cost_logs_task_id`
- `CostLogModel.task_id` + `_to_model` / `_to_entity` round-trip
- `PgCostRepository.get_cache_hit_rate_for_task` replaces the step 2 stub with a single `SUM(cached_tokens), SUM(prompt_tokens) WHERE task_id = :task_id` aggregation (zero-denominator guard preserved)

Step 3 of 4 in the TD-189 series. Step 2 (port + InMemory impl) merged in #28.

## Test plan
- [x] 2 new mapping tests + 4 SQL tests in `tests/unit/infrastructure/test_pg_repositories.py` (25/25 green)
- [x] Full unit suite: 3,217 passed, 0 regressions
- [x] `ruff check` clean
- [x] `alembic upgrade head --sql` previews `ALTER TABLE cost_logs ADD COLUMN task_id VARCHAR(255)` + `CREATE INDEX ix_cost_logs_task_id`
- [ ] Step 4 will plumb `task_id` through CostTracker via ContextVar and wire `get_cache_hit_rate_for_task` into `ExecuteTaskUseCase._safe_record_execution`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost logs can now be associated with individual tasks, enabling detailed per-task cost tracking and analysis
  * Cache hit rate metrics are now calculated on a per-task basis, providing insights into caching efficiency for each task

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/29)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->