### PR TITLE
feat(cost): TD-189 step 4 — ContextVar plumbing + ExecutionRecord.cache_hit_rate

### DIFF
--- a/application/use_cases/execute_task.py
+++ b/application/use_cases/execute_task.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from domain.entities.execution_record import ExecutionRecord
 from domain.entities.task import TaskEntity
+from domain.ports.cost_repository import CostRepository
 from domain.ports.execution_record_repository import ExecutionRecordRepository
 from domain.ports.task_engine import TaskEngine
 from domain.ports.task_repository import TaskRepository
@@ -16,6 +17,7 @@ from domain.services.topic_extractor import TopicExtractor
 from domain.value_objects.agent_engine import AgentEngineType
 from domain.value_objects.model_tier import TaskType
 from domain.value_objects.status import SubTaskStatus, TaskStatus
+from shared.task_context import task_id_scope
 
 if TYPE_CHECKING:
     from application.use_cases.discover_tools import DiscoverToolsUseCase
@@ -55,6 +57,7 @@ class ExecuteTaskUseCase:
         discover_tools: DiscoverToolsUseCase | None = None,
         install_tool: InstallToolUseCase | None = None,
         execution_record_repo: ExecutionRecordRepository | None = None,
+        cost_repo: CostRepository | None = None,
         default_model: str = "ollama/qwen3:8b",
         event_bus: object | None = None,
         max_skill_retries: int = 1,
@@ -66,6 +69,7 @@ class ExecuteTaskUseCase:
         self._discover_tools = discover_tools
         self._install_tool = install_tool
         self._execution_record_repo = execution_record_repo
+        self._cost_repo = cost_repo
         self._default_model = default_model
         self._event_bus = event_bus
         self._max_skill_retries = max_skill_retries
@@ -81,6 +85,17 @@ class ExecuteTaskUseCase:
         if task is None:
             raise TaskNotFoundError(task_id)
 
+        with task_id_scope(task_id):
+            return await self._execute_in_scope(task, engine_type, model_used)
+
+    async def _execute_in_scope(
+        self,
+        task: TaskEntity,
+        engine_type: AgentEngineType,
+        model_used: str | None,
+    ) -> TaskEntity:
+        """Body of execute(), run while task_id_scope is active."""
+        task_id = task.id
         task.status = TaskStatus.RUNNING
         await self._repo.update(task)
 
@@ -174,6 +189,17 @@ class ExecuteTaskUseCase:
                 error_message = st.error
                 break
 
+        cache_hit_rate = 0.0
+        if self._cost_repo is not None:
+            try:
+                cache_hit_rate = await self._cost_repo.get_cache_hit_rate_for_task(task.id)
+            except Exception:
+                logger.debug(
+                    "cache_hit_rate lookup failed for task %s — defaulting to 0.0",
+                    task.id,
+                    exc_info=True,
+                )
+
         record = ExecutionRecord(
             task_id=task.id,
             task_type=self._infer_task_type(task.goal),
@@ -184,7 +210,7 @@ class ExecuteTaskUseCase:
             error_message=error_message,
             cost_usd=task.total_cost_usd,
             duration_seconds=duration_s,
-            cache_hit_rate=0.0,
+            cache_hit_rate=cache_hit_rate,
         )
 
         try:

--- a/domain/entities/cost.py
+++ b/domain/entities/cost.py
@@ -33,6 +33,7 @@ class CostRecord(BaseModel):
         model_used: str | None,
         cost_usd: float,
         is_local: bool = False,
+        task_id: str | None = None,
     ) -> CostRecord:
         """Create a CostRecord from an agent engine execution result."""
         return cls(
@@ -43,5 +44,6 @@ class CostRecord(BaseModel):
             cached_tokens=0,
             is_local=is_local,
             engine_type=engine_type,
+            task_id=task_id,
             timestamp=datetime.now(UTC),
         )

--- a/infrastructure/llm/cost_tracker.py
+++ b/infrastructure/llm/cost_tracker.py
@@ -10,6 +10,7 @@ from domain.ports.agent_engine import AgentEngineResult
 from domain.ports.cost_repository import CostRepository
 from domain.ports.engine_cost_recorder import EngineCostRecorderPort
 from domain.ports.llm_gateway import LLMResponse
+from shared.task_context import get_current_task_id
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ class CostTracker(EngineCostRecorderPort):
             cost_usd=response.cost_usd,
             cached_tokens=response.cached_tokens,
             is_local=response.model.startswith("ollama/"),
+            task_id=get_current_task_id(),
             timestamp=datetime.now(UTC),
         )
         await self._repo.save(record)
@@ -49,6 +51,7 @@ class CostTracker(EngineCostRecorderPort):
             model_used=result.model_used,
             cost_usd=result.cost_usd,
             is_local=is_local,
+            task_id=get_current_task_id(),
         )
         try:
             await self._repo.save(record)

--- a/interface/api/container.py
+++ b/interface/api/container.py
@@ -285,6 +285,7 @@ class AppContainer:
             discover_tools=self.discover_tools,
             install_tool=self.install_tool,
             execution_record_repo=self.execution_record_repo,
+            cost_repo=self.cost_repo,
             default_model=self.settings.ollama_default_model,
             event_bus=self.event_bus,
             max_skill_retries=1,

--- a/shared/task_context.py
+++ b/shared/task_context.py
@@ -1,0 +1,33 @@
+"""Task ID propagation via ContextVar — cross-cutting cost attribution.
+
+ContextVar lets us thread a ``task_id`` through async code without changing
+every function signature: nested awaits inherit the caller's context, so
+``CostTracker.record`` can stamp the active task on each ``CostRecord``.
+
+Use ``task_id_scope`` as a context manager around code that should be
+attributed to a single task. ``get_current_task_id`` returns the active id
+or ``None`` when no scope is active.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_current_task_id: ContextVar[str | None] = ContextVar("current_task_id", default=None)
+
+
+def get_current_task_id() -> str | None:
+    """Return the task_id of the active scope, or None."""
+    return _current_task_id.get()
+
+
+@contextmanager
+def task_id_scope(task_id: str) -> Iterator[None]:
+    """Bind ``task_id`` as the active task for the duration of the block."""
+    token = _current_task_id.set(task_id)
+    try:
+        yield
+    finally:
+        _current_task_id.reset(token)

--- a/tests/unit/infrastructure/test_cost_tracker.py
+++ b/tests/unit/infrastructure/test_cost_tracker.py
@@ -202,3 +202,42 @@ class TestRecordEngineResult:
         repo.save = AsyncMock(side_effect=RuntimeError("DB down"))
         # Should not raise
         await tracker.record_engine_result(_make_engine_result())
+
+
+# ═══════════════════════════════════════════════════════════════
+# TD-189 step 4: task_id propagation via ContextVar
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestTaskIdPropagation:
+    """CostTracker must stamp the active task_id from shared.task_context."""
+
+    async def test_llm_record_stamps_active_task_id(
+        self, tracker: CostTracker, repo: InMemoryCostRepository
+    ) -> None:
+        from shared.task_context import task_id_scope
+
+        with task_id_scope("task-42"):
+            await tracker.record(_make_response(model="claude-sonnet-4-6", cost=0.01))
+        assert repo.records[0].task_id == "task-42"
+
+    async def test_llm_record_task_id_none_outside_scope(
+        self, tracker: CostTracker, repo: InMemoryCostRepository
+    ) -> None:
+        await tracker.record(_make_response(model="claude-sonnet-4-6", cost=0.01))
+        assert repo.records[0].task_id is None
+
+    async def test_engine_result_stamps_active_task_id(
+        self, tracker: CostTracker, repo: InMemoryCostRepository
+    ) -> None:
+        from shared.task_context import task_id_scope
+
+        with task_id_scope("task-99"):
+            await tracker.record_engine_result(_make_engine_result(cost_usd=0.05))
+        assert repo.records[0].task_id == "task-99"
+
+    async def test_engine_result_task_id_none_outside_scope(
+        self, tracker: CostTracker, repo: InMemoryCostRepository
+    ) -> None:
+        await tracker.record_engine_result(_make_engine_result(cost_usd=0.05))
+        assert repo.records[0].task_id is None

--- a/tests/unit/shared/test_task_context.py
+++ b/tests/unit/shared/test_task_context.py
@@ -1,0 +1,64 @@
+"""TD-189 step 4: shared.task_context — ContextVar-based task_id propagation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from shared.task_context import get_current_task_id, task_id_scope
+
+
+def test_default_is_none() -> None:
+    assert get_current_task_id() is None
+
+
+def test_scope_sets_and_restores() -> None:
+    assert get_current_task_id() is None
+    with task_id_scope("task-A"):
+        assert get_current_task_id() == "task-A"
+    assert get_current_task_id() is None
+
+
+def test_scope_resets_on_exception() -> None:
+    with pytest.raises(RuntimeError), task_id_scope("task-B"):
+        assert get_current_task_id() == "task-B"
+        raise RuntimeError("boom")
+    assert get_current_task_id() is None
+
+
+def test_nested_scope() -> None:
+    with task_id_scope("outer"):
+        assert get_current_task_id() == "outer"
+        with task_id_scope("inner"):
+            assert get_current_task_id() == "inner"
+        assert get_current_task_id() == "outer"
+    assert get_current_task_id() is None
+
+
+@pytest.mark.asyncio
+async def test_async_scope_propagates_through_await() -> None:
+    async def read_id() -> str | None:
+        await asyncio.sleep(0)
+        return get_current_task_id()
+
+    with task_id_scope("async-task"):
+        assert await read_id() == "async-task"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tasks_isolated() -> None:
+    """asyncio.gather'd tasks must each carry their own scope."""
+
+    async def run(task_id: str, observed: list[str | None]) -> None:
+        with task_id_scope(task_id):
+            await asyncio.sleep(0.01)
+            observed.append(get_current_task_id())
+
+    a: list[str | None] = []
+    b: list[str | None] = []
+    await asyncio.gather(run("alpha", a), run("beta", b))
+
+    assert a == ["alpha"]
+    assert b == ["beta"]
+    assert get_current_task_id() is None


### PR DESCRIPTION
## Summary
- Introduce `shared/task_context.py` with `ContextVar`-based `task_id_scope` / `get_current_task_id` so async-safe task attribution propagates through `await` and `asyncio.gather` without changing port signatures.
- `CostTracker.record` / `record_engine_result` now stamp every `CostRecord` with the active task_id.
- `ExecuteTaskUseCase` wraps execution in `task_id_scope(task_id)` and resolves `cache_hit_rate` from `CostRepository.get_cache_hit_rate_for_task` when persisting `ExecutionRecord`, closing the TD-189 loop (steps 1-3 landed the plumbing, this step wires it end-to-end).
- DI container passes `cost_repo` into `ExecuteTaskUseCase`.

## Why
TD-189 needs per-task cache-hit ratios in `ExecutionRecord` so harness-optimizer and cost-guardian can reason about Anthropic prompt-cache effectiveness. The other 3 steps moved the data to where it could be queried; this PR plugs the cross-cutting task_id into the cost path and reads the aggregate back at record time.

## Test plan
- [x] `tests/unit/shared/test_task_context.py` — 6 tests covering default/scope/exception/nested/async await/`asyncio.gather` isolation
- [x] `tests/unit/infrastructure/test_cost_tracker.py::TestTaskIdPropagation` — 4 tests for `record` + `record_engine_result` stamping inside/outside scope
- [x] Full unit suite: 3227 passed
- [x] `ruff check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)