### PR TITLE
perf(fractal): TD-192 fold output_requirement into bypass classifier

### DIFF
--- a/infrastructure/fractal/bypass_classifier.py
+++ b/infrastructure/fractal/bypass_classifier.py
@@ -17,6 +17,7 @@ import re
 from dataclasses import dataclass
 
 from domain.ports.llm_gateway import LLMGateway
+from domain.value_objects.output_requirement import OutputRequirement
 from domain.value_objects.task_complexity import TaskComplexity
 
 logger = logging.getLogger(__name__)
@@ -25,13 +26,17 @@ logger = logging.getLogger(__name__)
 # Stable system prompt (KV-cache friendly — never changes)
 # ---------------------------------------------------------------------------
 _CLASSIFY_SYSTEM = """\
-You are a task complexity classifier. Analyze the user's goal and determine \
-whether it can be completed in a SINGLE step or requires multi-step planning.
+You are a task classifier. Analyze the user's goal on TWO axes and return a \
+single JSON object combining both signals:
 
 Respond with ONLY a JSON object (no other text):
-{"complexity": "SIMPLE" | "MEDIUM" | "COMPLEX", "reason": "one sentence"}
+{
+  "complexity": "SIMPLE" | "MEDIUM" | "COMPLEX",
+  "output_requirement": "text" | "file" | "code" | "data",
+  "reason": "one sentence"
+}
 
-Definitions:
+Complexity definitions:
 SIMPLE = Answerable in ONE step with a single LLM call. No external tools, \
 no research, no multi-step coordination needed.
   Examples: "What is 2+2?", "Write a fibonacci function in Python", \
@@ -45,17 +50,37 @@ COMPLEX = Requires 4+ steps, multiple tools, architecture decisions, or deep \
 investigation across many files.
   Examples: "Refactor the auth system to use OAuth2", "Build a full-stack app"
 
-IMPORTANT: When uncertain, choose MEDIUM. It is safer to plan than to skip.\
+Output requirement definitions:
+- "text": A textual answer or explanation is sufficient.
+- "file": A file deliverable is required (slide, PDF, report, spreadsheet, \
+image, presentation, etc.).
+- "code": A code file or script must be produced.
+- "data": External data must be fetched, analyzed, or structured.
+
+IMPORTANT: When uncertain about complexity, choose MEDIUM. It is safer to plan \
+than to skip. When uncertain about output_requirement, choose "text".\
 """
+
+_REQUIREMENT_VALUE_MAP: dict[str, OutputRequirement] = {
+    "text": OutputRequirement.TEXT,
+    "file": OutputRequirement.FILE_ARTIFACT,
+    "code": OutputRequirement.CODE_ARTIFACT,
+    "data": OutputRequirement.DATA_ARTIFACT,
+}
 
 
 @dataclass(frozen=True)
 class BypassDecision:
-    """Result of the bypass classification."""
+    """Result of the combined bypass + output-requirement classification.
+
+    A single LLM call yields both signals (TD-192). Bypass is gated to TEXT
+    outputs: artifact-producing goals always take the fractal path.
+    """
 
     bypass: bool
     complexity: TaskComplexity
     reason: str
+    output_requirement: OutputRequirement = OutputRequirement.TEXT
 
 
 def _extract_json_object(text: str) -> str:
@@ -118,11 +143,17 @@ class FractalBypassClassifier:
                 bypass=False,
                 complexity=TaskComplexity.MEDIUM,
                 reason="LLM classification failed, defaulting to fractal planning",
+                output_requirement=OutputRequirement.TEXT,
             )
 
     @staticmethod
     def _parse_response(content: str) -> BypassDecision:
-        """Parse LLM classification response into a BypassDecision."""
+        """Parse LLM classification response into a BypassDecision.
+
+        TD-192: gates ``bypass=True`` to ``output_requirement == TEXT``.
+        SIMPLE-but-non-TEXT goals must take the fractal path so that the
+        artifact-producing terminal nodes are properly evaluated by Gate ②.
+        """
         raw = _extract_json_object(content)
         try:
             data = json.loads(raw)
@@ -132,26 +163,37 @@ class FractalBypassClassifier:
                 bypass=False,
                 complexity=TaskComplexity.MEDIUM,
                 reason="Unparseable LLM response, defaulting to fractal",
+                output_requirement=OutputRequirement.TEXT,
             )
 
         complexity_str = str(data.get("complexity", "MEDIUM")).upper()
         reason = str(data.get("reason", "LLM classification"))
+        requirement_str = str(data.get("output_requirement", "text")).lower().strip()
+        output_requirement = _REQUIREMENT_VALUE_MAP.get(
+            requirement_str, OutputRequirement.TEXT,
+        )
 
         if complexity_str == "SIMPLE":
+            # TD-192: bypass only when output is plain text — artifact goals
+            # must run the fractal path so terminal nodes are gated by output.
+            bypass = output_requirement == OutputRequirement.TEXT
             return BypassDecision(
-                bypass=True,
+                bypass=bypass,
                 complexity=TaskComplexity.SIMPLE,
                 reason=reason,
+                output_requirement=output_requirement,
             )
         if complexity_str == "COMPLEX":
             return BypassDecision(
                 bypass=False,
                 complexity=TaskComplexity.COMPLEX,
                 reason=reason,
+                output_requirement=output_requirement,
             )
         # MEDIUM or anything else → don't bypass
         return BypassDecision(
             bypass=False,
             complexity=TaskComplexity.MEDIUM,
             reason=reason,
+            output_requirement=output_requirement,
         )

--- a/infrastructure/fractal/fractal_engine.py
+++ b/infrastructure/fractal/fractal_engine.py
@@ -64,7 +64,6 @@ from infrastructure.fractal.node_executor import NodeExecutor
 
 if TYPE_CHECKING:
     from domain.ports.task_repository import TaskRepository
-    from domain.services.output_requirement_classifier import OutputRequirementClassifier
     from infrastructure.fractal.bypass_classifier import FractalBypassClassifier
 
 logger = logging.getLogger(__name__)
@@ -119,7 +118,6 @@ class FractalTaskEngine(TaskEngine):
         cache_planner_candidates: bool = False,
         max_concurrent_nodes: int = 0,
         throttle_delay_ms: int = 0,
-        output_classifier: OutputRequirementClassifier | None = None,
         max_execution_seconds: int = 180,
     ) -> None:
         self._planner = planner
@@ -166,9 +164,6 @@ class FractalTaskEngine(TaskEngine):
         # Concurrency throttle: limit parallel node execution (TD-175)
         self._max_concurrent_nodes = max_concurrent_nodes  # 0 = unlimited
         self._throttle_delay_ms = throttle_delay_ms
-
-        # Output-aware evaluation: classifier for goal output requirements
-        self._output_classifier = output_classifier
 
         # TD-181: Time-based timeout — hard limit to prevent zombie tasks.
         # Kills execution after max_execution_seconds regardless of retries/reflection.
@@ -292,33 +287,21 @@ class FractalTaskEngine(TaskEngine):
         # TD-175: Apply per-execution concurrency/throttle overrides
         self._apply_execution_overrides()
 
-        # TD-191: Classify output requirement BEFORE bypass so non-text goals
-        # (file/code/data artifacts) cannot be short-circuited by a bypass
-        # misclassification — Round 19 root-cause fix.
+        # TD-192: SIMPLE-task bypass + output-requirement classification in
+        # a single LLM call. BypassDecision carries both signals; the
+        # classifier internally gates bypass to TEXT-only outputs so that
+        # artifact-producing goals always take the fractal path (the
+        # Round 19 fix is preserved at the source).
         goal_output_req: OutputRequirement | None = None
-        if self._output_classifier is not None:
-            try:
-                goal_output_req = await self._output_classifier.classify(task.goal)
-                logger.info(
-                    "Output requirement for goal: %s", goal_output_req.value
-                )
-            except Exception:
-                logger.warning(
-                    "Output requirement classification failed — skipping",
-                    exc_info=True,
-                )
-
-        # TD-167 + TD-191: SIMPLE task bypass — LLM intent analysis,
-        # gated to TEXT-only outputs. Artifact-producing goals always take
-        # the fractal path even when the bypass classifier says SIMPLE.
-        bypass_allowed_by_output = goal_output_req in (None, OutputRequirement.TEXT)
-        if self._bypass_classifier is not None and bypass_allowed_by_output:
+        if self._bypass_classifier is not None:
             try:
                 decision = await self._bypass_classifier.should_bypass(task.goal)
+                goal_output_req = decision.output_requirement
                 logger.info(
-                    "Bypass classifier: bypass=%s complexity=%s reason=%r",
+                    "Bypass classifier: bypass=%s complexity=%s output=%s reason=%r",
                     decision.bypass,
                     decision.complexity.value,
+                    decision.output_requirement.value,
                     decision.reason[:100],
                 )
                 if decision.bypass:
@@ -328,11 +311,6 @@ class FractalTaskEngine(TaskEngine):
                     "Bypass classification error — falling through to fractal",
                     exc_info=True,
                 )
-        elif self._bypass_classifier is not None:
-            logger.info(
-                "Bypass skipped: output requirement is %s (non-TEXT)",
-                goal_output_req.value if goal_output_req else "unknown",
-            )
 
         try:
             plan = await self._generate_approved_plan(task.goal, nesting_level=0)

--- a/interface/api/container.py
+++ b/interface/api/container.py
@@ -364,15 +364,11 @@ class AppContainer:
 
         reflection_evaluator = LLMReflectionEvaluator(llm=self.llm)
 
-        # TD-167: SIMPLE task bypass — LLM intent analysis classifier
+        # TD-167 + TD-192: SIMPLE task bypass + output-requirement classifier,
+        # collapsed into a single LLM call via BypassDecision.
         from infrastructure.fractal.bypass_classifier import FractalBypassClassifier
 
         bypass_classifier = FractalBypassClassifier(llm=self.llm)
-
-        # Output-aware evaluation: classify goal output requirements
-        from domain.services.output_requirement_classifier import OutputRequirementClassifier
-
-        output_classifier = OutputRequirementClassifier(llm=self.llm)
 
         logger.info(
             "FractalTaskEngine enabled (depth=%d, retries=%d, reflect=%d, bypass=on)",
@@ -403,7 +399,6 @@ class AppContainer:
             cache_planner_candidates=True,  # TD-173: skip LLM on repeat goals
             max_concurrent_nodes=self.settings.fractal_max_concurrent_nodes,  # TD-175
             throttle_delay_ms=self.settings.fractal_throttle_delay_ms,  # TD-175
-            output_classifier=output_classifier,
             max_execution_seconds=self.settings.fractal_max_execution_seconds,  # TD-181
         )
 

--- a/tests/integration/test_round19_regression.py
+++ b/tests/integration/test_round19_regression.py
@@ -199,7 +199,6 @@ class TestRound19EndToEnd:
     async def test_round19_goal_takes_fractal_path(
         self,
         bypass_classifier: FractalBypassClassifier,
-        output_classifier: OutputRequirementClassifier,
     ) -> None:
         """The exact goal that broke Round 19 must NOT trigger bypass."""
         planner, pe, re_, inner = _stub_planning_path()
@@ -207,7 +206,6 @@ class TestRound19EndToEnd:
             planner=planner, plan_evaluator=pe, result_evaluator=re_,
             inner_engine=inner,
             bypass_classifier=bypass_classifier,
-            output_classifier=output_classifier,
         )
 
         task = TaskEntity(goal=ROUND_19_GOAL)
@@ -223,7 +221,6 @@ class TestRound19EndToEnd:
     async def test_simple_question_still_bypasses(
         self,
         bypass_classifier: FractalBypassClassifier,
-        output_classifier: OutputRequirementClassifier,
     ) -> None:
         """TD-167's latency win for legitimate text Q&A must be preserved."""
         planner, pe, re_, inner = _stub_planning_path()
@@ -231,7 +228,6 @@ class TestRound19EndToEnd:
             planner=planner, plan_evaluator=pe, result_evaluator=re_,
             inner_engine=inner,
             bypass_classifier=bypass_classifier,
-            output_classifier=output_classifier,
         )
 
         task = TaskEntity(goal="What is 2+2?")

--- a/tests/unit/infrastructure/test_fractal_bypass.py
+++ b/tests/unit/infrastructure/test_fractal_bypass.py
@@ -194,7 +194,11 @@ class TestLLMClassification:
 # ---------------------------------------------------------------------------
 
 
-def _make_fractal_mocks(*, classifier_bypass: bool = True):
+def _make_fractal_mocks(
+    *,
+    classifier_bypass: bool = True,
+    output_requirement: OutputRequirement = OutputRequirement.TEXT,
+):
     """Create common mocks for FractalTaskEngine bypass tests."""
     # Mock classifier
     classifier = AsyncMock()
@@ -204,6 +208,7 @@ def _make_fractal_mocks(*, classifier_bypass: bool = True):
             TaskComplexity.SIMPLE if classifier_bypass else TaskComplexity.MEDIUM
         ),
         reason="test",
+        output_requirement=output_requirement,
     )
 
     # Mock planner + evaluators (for fractal path)
@@ -342,35 +347,31 @@ class TestFractalEngineBypass:
 
 
 # ---------------------------------------------------------------------------
-# TD-191: Output-requirement gate on bypass (Round 19 architectural fix)
+# TD-191 / TD-192: Output-requirement gate inside the bypass classifier
 # ---------------------------------------------------------------------------
 
 
-def _output_classifier(requirement: OutputRequirement) -> AsyncMock:
-    """Mock OutputRequirementClassifier returning a fixed requirement."""
-    cls = AsyncMock()
-    cls.classify.return_value = requirement
-    return cls
-
-
 class TestBypassOutputGate:
-    """When OutputRequirementClassifier reports a non-TEXT requirement, the
-    bypass path MUST be skipped — even if the bypass LLM said SIMPLE.
+    """The bypass classifier now carries ``output_requirement`` itself
+    (TD-192). When the LLM reports a non-TEXT requirement, ``BypassDecision``
+    is internally clamped to ``bypass=False`` so the engine takes the
+    fractal path even if complexity was SIMPLE.
 
     Round 19 (2026-04-13): bypass misclassified a slide-creation goal as
-    SIMPLE → no slide was ever produced. TD-191 closes the gap by requiring
-    output_requirement == TEXT for bypass to fire."""
+    SIMPLE → no slide was ever produced. TD-191 introduced the gate as a
+    separate ``OutputRequirementClassifier`` call; TD-192 folds it into the
+    bypass call to save one LLM round-trip while preserving the guarantee."""
 
     @pytest.mark.asyncio
     async def test_file_artifact_blocks_bypass(self) -> None:
-        """FILE_ARTIFACT goals must take the fractal path even if bypass=True."""
+        """FILE_ARTIFACT goals must take the fractal path even if SIMPLE."""
         classifier, planner, pe, re_, inner = _make_fractal_mocks(
-            classifier_bypass=True,
+            classifier_bypass=False,  # parse_response would clamp this
+            output_requirement=OutputRequirement.FILE_ARTIFACT,
         )
         engine = FractalTaskEngine(
             planner=planner, plan_evaluator=pe, result_evaluator=re_,
             inner_engine=inner, bypass_classifier=classifier,
-            output_classifier=_output_classifier(OutputRequirement.FILE_ARTIFACT),
         )
 
         task = TaskEntity(goal="氷川神社のスライドを作って")
@@ -382,12 +383,12 @@ class TestBypassOutputGate:
     @pytest.mark.asyncio
     async def test_code_artifact_blocks_bypass(self) -> None:
         classifier, planner, pe, re_, inner = _make_fractal_mocks(
-            classifier_bypass=True,
+            classifier_bypass=False,
+            output_requirement=OutputRequirement.CODE_ARTIFACT,
         )
         engine = FractalTaskEngine(
             planner=planner, plan_evaluator=pe, result_evaluator=re_,
             inner_engine=inner, bypass_classifier=classifier,
-            output_classifier=_output_classifier(OutputRequirement.CODE_ARTIFACT),
         )
         task = TaskEntity(goal="Write hello.py and save it")
         await engine.execute(task)
@@ -396,12 +397,12 @@ class TestBypassOutputGate:
     @pytest.mark.asyncio
     async def test_data_artifact_blocks_bypass(self) -> None:
         classifier, planner, pe, re_, inner = _make_fractal_mocks(
-            classifier_bypass=True,
+            classifier_bypass=False,
+            output_requirement=OutputRequirement.DATA_ARTIFACT,
         )
         engine = FractalTaskEngine(
             planner=planner, plan_evaluator=pe, result_evaluator=re_,
             inner_engine=inner, bypass_classifier=classifier,
-            output_classifier=_output_classifier(OutputRequirement.DATA_ARTIFACT),
         )
         task = TaskEntity(goal="Fetch the latest stock prices")
         await engine.execute(task)
@@ -412,11 +413,11 @@ class TestBypassOutputGate:
         """TEXT goals may still bypass — preserves TD-167 latency win."""
         classifier, planner, pe, re_, inner = _make_fractal_mocks(
             classifier_bypass=True,
+            output_requirement=OutputRequirement.TEXT,
         )
         engine = FractalTaskEngine(
             planner=planner, plan_evaluator=pe, result_evaluator=re_,
             inner_engine=inner, bypass_classifier=classifier,
-            output_classifier=_output_classifier(OutputRequirement.TEXT),
         )
         task = TaskEntity(goal="What is 2+2?")
         await engine.execute(task)
@@ -425,41 +426,95 @@ class TestBypassOutputGate:
         inner.execute.assert_called_once()
         planner.generate_candidates.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_no_output_classifier_preserves_legacy_bypass(self) -> None:
-        """When output_classifier is not wired, bypass behaves as in TD-167."""
-        classifier, planner, pe, re_, inner = _make_fractal_mocks(
-            classifier_bypass=True,
-        )
-        engine = FractalTaskEngine(
-            planner=planner, plan_evaluator=pe, result_evaluator=re_,
-            inner_engine=inner, bypass_classifier=classifier,
-            # No output_classifier
-        )
-        task = TaskEntity(goal="What is 2+2?")
-        await engine.execute(task)
 
-        inner.execute.assert_called_once()
-        planner.generate_candidates.assert_not_called()
+class TestParseResponseGate:
+    """``_parse_response`` must clamp ``bypass`` to ``False`` whenever
+    ``output_requirement != TEXT`` even if complexity is SIMPLE."""
 
     @pytest.mark.asyncio
-    async def test_output_classifier_error_does_not_block_bypass(self) -> None:
-        """Classifier exception must not regress to permanent fractal fallback
-        for legitimate text Q&A. Fail-open is acceptable here because the
-        bypass classifier has its own confidence check."""
-        classifier, planner, pe, re_, inner = _make_fractal_mocks(
-            classifier_bypass=True,
-        )
-        broken_output = AsyncMock()
-        broken_output.classify.side_effect = RuntimeError("LLM down")
+    async def test_simple_text_returns_bypass(self) -> None:
+        llm = _mock_llm(json.dumps({
+            "complexity": "SIMPLE",
+            "output_requirement": "text",
+            "reason": "trivial",
+        }))
+        classifier = FractalBypassClassifier(llm=llm)
+        decision = await classifier.should_bypass("What is 2+2?")
+        assert decision.bypass is True
+        assert decision.output_requirement == OutputRequirement.TEXT
 
-        engine = FractalTaskEngine(
-            planner=planner, plan_evaluator=pe, result_evaluator=re_,
-            inner_engine=inner, bypass_classifier=classifier,
-            output_classifier=broken_output,
-        )
-        task = TaskEntity(goal="What is 2+2?")
-        await engine.execute(task)
+    @pytest.mark.asyncio
+    async def test_simple_file_blocks_bypass(self) -> None:
+        llm = _mock_llm(json.dumps({
+            "complexity": "SIMPLE",
+            "output_requirement": "file",
+            "reason": "slide artifact",
+        }))
+        classifier = FractalBypassClassifier(llm=llm)
+        decision = await classifier.should_bypass("Make a slide deck")
+        # SIMPLE complexity preserved, but bypass clamped because non-TEXT
+        assert decision.complexity == TaskComplexity.SIMPLE
+        assert decision.output_requirement == OutputRequirement.FILE_ARTIFACT
+        assert decision.bypass is False
 
-        # Fail-open: bypass still fires when classifier errors
-        inner.execute.assert_called_once()
+    @pytest.mark.asyncio
+    async def test_simple_code_blocks_bypass(self) -> None:
+        llm = _mock_llm(json.dumps({
+            "complexity": "SIMPLE",
+            "output_requirement": "code",
+            "reason": "needs a real file",
+        }))
+        classifier = FractalBypassClassifier(llm=llm)
+        decision = await classifier.should_bypass("Write hello.py and save it")
+        assert decision.bypass is False
+        assert decision.output_requirement == OutputRequirement.CODE_ARTIFACT
+
+    @pytest.mark.asyncio
+    async def test_simple_data_blocks_bypass(self) -> None:
+        llm = _mock_llm(json.dumps({
+            "complexity": "SIMPLE",
+            "output_requirement": "data",
+            "reason": "needs fresh data",
+        }))
+        classifier = FractalBypassClassifier(llm=llm)
+        decision = await classifier.should_bypass("Fetch latest prices")
+        assert decision.bypass is False
+        assert decision.output_requirement == OutputRequirement.DATA_ARTIFACT
+
+    @pytest.mark.asyncio
+    async def test_missing_output_requirement_defaults_to_text(self) -> None:
+        """Backward compat: classifiers that omit output_requirement still bypass."""
+        llm = _mock_llm(json.dumps({
+            "complexity": "SIMPLE",
+            "reason": "no output field",
+        }))
+        classifier = FractalBypassClassifier(llm=llm)
+        decision = await classifier.should_bypass("What is 2+2?")
+        assert decision.bypass is True
+        assert decision.output_requirement == OutputRequirement.TEXT
+
+    @pytest.mark.asyncio
+    async def test_unknown_output_requirement_falls_back_to_text(self) -> None:
+        llm = _mock_llm(json.dumps({
+            "complexity": "SIMPLE",
+            "output_requirement": "alien",
+            "reason": "garbage value",
+        }))
+        classifier = FractalBypassClassifier(llm=llm)
+        decision = await classifier.should_bypass("test")
+        assert decision.bypass is True
+        assert decision.output_requirement == OutputRequirement.TEXT
+
+    @pytest.mark.asyncio
+    async def test_complex_carries_output_requirement(self) -> None:
+        """Non-SIMPLE decisions still expose the parsed output requirement."""
+        llm = _mock_llm(json.dumps({
+            "complexity": "COMPLEX",
+            "output_requirement": "file",
+            "reason": "big task",
+        }))
+        classifier = FractalBypassClassifier(llm=llm)
+        decision = await classifier.should_bypass("Build a slide deck app")
+        assert decision.bypass is False
+        assert decision.complexity == TaskComplexity.COMPLEX
+        assert decision.output_requirement == OutputRequirement.FILE_ARTIFACT


### PR DESCRIPTION
## Summary
- Combine `FractalBypassClassifier.should_bypass()` and `OutputRequirementClassifier.classify()` into a **single LLM call**.
- `BypassDecision` now carries `(bypass, complexity, output_requirement, reason)`.
- Internal gating in `_parse_response` clamps `bypass=False` whenever `output_requirement != TEXT`, preserving the TD-191 architectural guard at the source.
- Removes `output_classifier` parameter from `FractalTaskEngine` and the DI wiring in `interface/api/container.py`.
- One less LLM round-trip per fractal task entry.

## Why
TD-167 (SIMPLE bypass) and TD-191 (output gate) were two sequential LLM calls per task. Folding them eliminates a round-trip while keeping the Round 19 fix architecturally enforced — artifact-producing goals still take the fractal path even when classified SIMPLE.

## Test plan
- [x] Unit: `tests/unit/infrastructure/test_fractal_bypass.py` — rewrote `TestBypassOutputGate` to use `BypassDecision.output_requirement`; added `TestParseResponseGate` (7 tests) for the internal gating logic.
- [x] Unit regression: 3232 passed.
- [x] Integration: `tests/integration/test_round19_regression.py` 6/6 PASS against real Ollama (`qwen3:8b`). Round 19 goal still takes fractal path; "What is 2+2?" still bypasses.
- [x] `ruff check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined task classification by consolidating complexity and output requirement analysis into a single decision point, reducing overhead.
  * Refined bypass routing to restrict simple task bypass to text-only outputs; tasks requiring code, file, or data responses now use the complete processing path for improved accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/31)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->