### PR TITLE
chore(bench): add --pad-entries to cache_hit_rate for threshold sweeps

### DIFF
--- a/benchmarks/cache_hit_rate.py
+++ b/benchmarks/cache_hit_rate.py
@@ -33,7 +33,13 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger("cache_hit_rate")
 
 
-async def _run(model: str, calls: int, goal: str, verify_wiring: bool) -> None:
+async def _run(
+    model: str,
+    calls: int,
+    goal: str,
+    verify_wiring: bool,
+    pad_entries: int = 160,
+) -> None:
     settings = Settings()
     if "claude" in model and not settings.has_anthropic:
         raise SystemExit("ANTHROPIC_API_KEY is required for Claude models.")
@@ -61,7 +67,7 @@ async def _run(model: str, calls: int, goal: str, verify_wiring: bool) -> None:
                 f"the cached portion of the system prompt above the provider "
                 f"minimum (~2048 tokens empirically for Claude 4) so cache "
                 f"reads can be observed end-to-end."
-                for i in range(160)
+                for i in range(pad_entries)
             )
         )
         original = _planner_mod._SYSTEM_PROMPT
@@ -126,9 +132,27 @@ def _parse() -> argparse.Namespace:
             "cache_control wiring works end-to-end; not a normal workload."
         ),
     )
+    p.add_argument(
+        "--pad-entries",
+        type=int,
+        default=160,
+        help=(
+            "Number of glossary entries appended to the SYSTEM prompt when "
+            "--verify-wiring is set. ~225 chars/entry → 160 ≈ 8.4K tokens. "
+            "Use to sweep cache thresholds."
+        ),
+    )
     return p.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse()
-    asyncio.run(_run(args.model, args.calls, args.goal, args.verify_wiring))
+    asyncio.run(
+        _run(
+            args.model,
+            args.calls,
+            args.goal,
+            args.verify_wiring,
+            args.pad_entries,
+        )
+    )


### PR DESCRIPTION
## Summary
- Add `--pad-entries N` flag to `benchmarks/cache_hit_rate.py` so the `--verify-wiring` pad size can be tuned independently of the default 160 entries (~8.4K tokens, ~50 tok/entry).
- Used to binary-search Claude Haiku 4.5's empirical prompt-cache minimum.

## Finding (TD-193 follow-up — Haiku 4.5 threshold pinned)

| pad_entries | prompt_tok | result |
|------------:|-----------:|:------:|
| 60          | 3475       | MISS   |
| 70          | 3965       | MISS   |
| 72          | 4063       | MISS   |
| 73          | 4112       | MISS   |
| 74          | 4161       | **HIT** |
| 80          | 4455       | HIT    |
| 100         | 5435       | HIT    |
| 160         | 8375       | HIT    |

**Empirical Claude 4 cache minimums (this account):**
- Sonnet 4.6 ≈ 2048 tokens (2^11)
- Haiku 4.5 ≈ 4096 tokens (2^12)

Both clean powers of 2; documented 1024-token minimum is wrong for both.

## Test plan
- [x] `ruff check benchmarks/cache_hit_rate.py` — clean.
- [x] Live: 8 sweeps against real Anthropic API (`claude-haiku-4-5-20251001`); each `--calls 3 --verify-wiring --pad-entries N`. Results above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)