### PR TITLE
feat(cli): TD-189 step 5 — surface per-task cache_hit_rate

### DIFF
--- a/interface/cli/commands/cost.py
+++ b/interface/cli/commands/cost.py
@@ -39,3 +39,20 @@ def budget_set(
         raise typer.Exit(code=1)
     c.settings.default_monthly_budget_usd = amount
     console.print(f"[green]Budget set:[/] ${amount:.2f}/month")
+
+
+@cost_app.command("task")
+def task_cache_hit_rate(
+    task_id: str = typer.Argument(..., help="Task ID to inspect."),
+) -> None:
+    """Show per-task Anthropic prompt-cache hit rate (TD-189 step 5)."""
+    c = _get_container()
+    rate = _run(c.cost_repo.get_cache_hit_rate_for_task(task_id))
+    style = (
+        "green" if rate >= 0.5
+        else "yellow" if rate >= 0.2
+        else "dim"
+    )
+    console.print(
+        f"Task [bold]{task_id}[/] cache hit rate: [{style}]{rate:.0%}[/]"
+    )

--- a/interface/cli/commands/task.py
+++ b/interface/cli/commands/task.py
@@ -34,7 +34,8 @@ def create(
             print_error(str(exc))
             raise typer.Exit(code=1) from exc
 
-    print_task_detail(task)
+    cache_hit_rate = _run(c.cost_repo.get_cache_hit_rate_for_task(task.id))
+    print_task_detail(task, cache_hit_rate=cache_hit_rate)
 
 
 @task_app.command("list")
@@ -55,7 +56,8 @@ def show(
     if task is None:
         print_error(f"Task {task_id} not found")
         raise typer.Exit(code=1)
-    print_task_detail(task)
+    cache_hit_rate = _run(c.cost_repo.get_cache_hit_rate_for_task(task.id))
+    print_task_detail(task, cache_hit_rate=cache_hit_rate)
 
 
 @task_app.command("cancel")

--- a/interface/cli/formatters.py
+++ b/interface/cli/formatters.py
@@ -70,12 +70,27 @@ def print_task_table(tasks: list[TaskEntity]) -> None:
     console.print(table)
 
 
-def print_task_detail(task: TaskEntity) -> None:
-    """Print a tree view of a single task with its subtasks."""
+def print_task_detail(
+    task: TaskEntity, cache_hit_rate: float | None = None,
+) -> None:
+    """Print a tree view of a single task with its subtasks.
+
+    If ``cache_hit_rate`` is provided (TD-189 step 5), the per-task
+    Anthropic prompt-cache hit rate is rendered as a percentage.
+    """
     tree = Tree(f"[bold]{task.goal}[/] ({_status_text(task.status.value)})")
     tree.add(f"ID: [dim]{task.id}[/]")
     tree.add(f"Cost: ${task.total_cost_usd:.4f}")
     tree.add(f"Success rate: {task.success_rate:.0%}")
+    if cache_hit_rate is not None:
+        rate_style = (
+            "green" if cache_hit_rate >= 0.5
+            else "yellow" if cache_hit_rate >= 0.2
+            else "dim"
+        )
+        tree.add(
+            f"Cache hit rate: [{rate_style}]{cache_hit_rate:.0%}[/]"
+        )
 
     if task.subtasks:
         st_branch = tree.add("[bold]Subtasks[/]")

--- a/tests/unit/interface/test_cli.py
+++ b/tests/unit/interface/test_cli.py
@@ -192,6 +192,29 @@ class TestTaskCommands:
         assert result.exit_code == 0
         assert "detail task" in result.output
 
+    def test_show_displays_cache_hit_rate(
+        self, container: _MockContainer
+    ) -> None:
+        """TD-189 step 5: task show must surface per-task cache_hit_rate."""
+        task = _make_task("cached task")
+        container.task_repo._store[task.id] = task
+        container.cost_repo._records.append(
+            CostRecord(
+                model="claude-haiku-4-5-20251001",
+                cost_usd=0.01,
+                is_local=False,
+                prompt_tokens=200,
+                cached_tokens=800,
+                task_id=task.id,
+            )
+        )
+
+        result = runner.invoke(app, ["task", "show", task.id])
+        assert result.exit_code == 0
+        # 800 cached / (200 prompt + 800 cached) = 80%
+        assert "Cache hit rate" in result.output
+        assert "80%" in result.output
+
     def test_show_not_found(self) -> None:
         result = runner.invoke(app, ["task", "show", "nonexistent"])
         assert result.exit_code == 1
@@ -297,6 +320,34 @@ class TestCostCommands:
         assert result.exit_code == 0
         assert "Budget set" in result.output
         assert "$100.00" in result.output
+
+    def test_task_cache_hit_rate_command(
+        self, container: _MockContainer
+    ) -> None:
+        """TD-189 step 5: cost task <id> reports per-task cache_hit_rate."""
+        task_id = "task-abc"
+        container.cost_repo._records.append(
+            CostRecord(
+                model="claude-haiku-4-5-20251001",
+                cost_usd=0.005,
+                is_local=False,
+                prompt_tokens=100,
+                cached_tokens=900,
+                task_id=task_id,
+            )
+        )
+
+        result = runner.invoke(app, ["cost", "task", task_id])
+        assert result.exit_code == 0
+        # 900 / (100 + 900) = 90%
+        assert "90%" in result.output
+        assert task_id in result.output
+
+    def test_task_cache_hit_rate_no_records(self) -> None:
+        """No records for the task → 0% reported, exit 0."""
+        result = runner.invoke(app, ["cost", "task", "unknown-task"])
+        assert result.exit_code == 0
+        assert "0%" in result.output
 
 
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Enrich `morphic task show` / `morphic task create` detail tree with color-coded per-task Anthropic prompt-cache hit rate
- Add new `morphic cost task <task_id>` subcommand for direct per-task cache hit rate query
- Color thresholds: green ≥50%, yellow ≥20%, dim <20%

Completes the surfacing step of TD-189 (per-task cache_hit_rate plumbing) — steps 1-4 already shipped the `CostRecord.task_id` field, `CostRepository.get_cache_hit_rate_for_task` port, `cost_logs.task_id` column + PG aggregation SQL, and ContextVar propagation. This PR exposes the metric in the CLI.

## Changes
- `interface/cli/formatters.py` — `print_task_detail` now accepts optional `cache_hit_rate` kwarg and renders as percentage
- `interface/cli/commands/task.py` — `show` and `create` pass `cache_hit_rate` fetched from `cost_repo.get_cache_hit_rate_for_task(task.id)`
- `interface/cli/commands/cost.py` — new `task` subcommand
- `tests/unit/interface/test_cli.py` — 3 new tests (task show / cost task / no-records edge case)

## Test plan
- [x] `uv run --extra dev pytest tests/unit/ -v` — 3,235 passed, 0 regressions
- [x] `uv run --extra dev ruff check .` — clean
- [x] RED → GREEN → REFACTOR cycle for all 3 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)