### PR TITLE
fix(plan-evaluator): unwrap arbitrarily-nested JSON list payloads

### DIFF
--- a/infrastructure/fractal/llm_plan_evaluator.py
+++ b/infrastructure/fractal/llm_plan_evaluator.py
@@ -172,8 +172,11 @@ class LLMPlanEvaluator(PlanEvaluatorPort):
             else:
                 raise
 
-        if isinstance(data, list) and data:
+        while isinstance(data, list) and data:
             data = data[0]
+
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected JSON object, got {type(data).__name__}")
 
         completeness = _clamp(float(data.get("completeness", 0.5)))
         feasibility = _clamp(float(data.get("feasibility", 0.5)))

--- a/tests/unit/infrastructure/test_llm_plan_evaluator.py
+++ b/tests/unit/infrastructure/test_llm_plan_evaluator.py
@@ -359,3 +359,27 @@ class TestJsonParsing:
         result = await evaluator.evaluate(plan, "Goal")
 
         assert result.completeness == pytest.approx(0.7, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_nested_list_payload_unwrapped(
+        self, llm: AsyncMock, evaluator: LLMPlanEvaluator
+    ) -> None:
+        """Regression: live A/B run observed `[[{...}]]` from the judge model.
+
+        The single-level guard was not enough — the second `data.get` blew up
+        and the call fell back to (0.5, 0.5, 1.0). Should unwrap any depth.
+        """
+        nested = (
+            "[[{"
+            '"completeness": 0.9, "feasibility": 0.8, "safety": 0.95, '
+            '"feedback": "nested"}]]'
+        )
+        llm.complete.return_value = _llm_response(nested)
+        plan = _sample_plan()
+
+        result = await evaluator.evaluate(plan, "Goal")
+
+        assert result.completeness == pytest.approx(0.9, abs=0.01)
+        assert result.feasibility == pytest.approx(0.8, abs=0.01)
+        assert result.safety == pytest.approx(0.95, abs=0.01)
+        assert "Fallback" not in result.feedback


### PR DESCRIPTION
## Summary
- Replace single-level `if` guard with `while` loop to unwrap any depth of nested-list JSON returned by the judge model
- Raise `ValueError` on non-dict so the existing exception handler routes cleanly into the fallback path
- Add regression test `test_nested_list_payload_unwrapped` covering the `[[{...}]]` shape observed live

## Context
During the Sonnet-vs-Haiku planner A/B benchmark (see `memory/haiku_planner_ab_2026_05_19.md`), the Sonnet judge returned `[[{...}]]` on 3/60 calls. The existing `if isinstance(data, list)` only popped one layer, then `data.get` raised `AttributeError` and the call fell back to (0.5, 0.5, 1.0) — marginally hurting the Haiku score in the A/B.

## Test plan
- [x] `pytest tests/unit/infrastructure/test_llm_plan_evaluator.py -v` — 17/17 pass (including new regression)
- [x] `ruff check infrastructure/fractal/llm_plan_evaluator.py tests/unit/infrastructure/test_llm_plan_evaluator.py` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced plan evaluation JSON parsing to properly unwrap nested array structures and enforce stricter validation of decoded JSON objects, improving reliability when handling complex LLM responses.

* **Tests**
  * Added regression test to verify correct extraction and processing of plan evaluation scores from nested JSON array payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/engkimo/open-morphic/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->